### PR TITLE
NMS bugfix

### DIFF
--- a/nms/pth_nms.py
+++ b/nms/pth_nms.py
@@ -40,7 +40,7 @@ def pth_nms(dets, thresh):
     order = scores.sort(0, descending=True)[1]
     # order = torch.from_numpy(np.ascontiguousarray(scores.cpu().numpy().argsort()[::-1])).long().cuda()
 
-    dets = dets[order].contiguous()
+    dets_temp = dets_temp[order].contiguous()
 
     keep = torch.LongTensor(dets.size(0))
     num_out = torch.LongTensor(1)


### PR DESCRIPTION
NMS is not working correctly, since the detections fed in are not sorted:

in nms/path_nms.py line 49:

nms.gpu_nms(keep, num_out, dets_temp, thresh)

the unordered 'dets_temp' are fed in instead of the ordered 'dets'.
This is solvable by either changing line 43 to :

dets_temp = dets_temp[order].contiguous()

or just getting rid of the dets_temp and feeding in dets, since NMS should be rotation invariant.